### PR TITLE
기존 코드에서 lockScreen 화면이 안나와 테스트

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,9 +9,8 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
-    <uses-permission android:name="android.permission.disable_keyguard"/>
+    <uses-permission android:name="android.permission.disable_keyguard" />
 
     <application
         android:name=".App"
@@ -31,31 +30,39 @@
             </intent-filter>
         </activity>
         <activity android:name=".utils.permissions.PermissionClass" />
-        <activity android:name=".views.alarmPlayView.AlarmPlayView"
+        <activity
+            android:name=".views.alarmPlayView.AlarmLockScreenView"
+            android:excludeFromRecents="true"
+            android:showOnLockScreen="true"
             android:showWhenLocked="true"
             android:turnScreenOn="true"
-            android:showOnLockScreen="true"
-            android:excludeFromRecents="true"/>
+            tools:targetApi="o_mr1" />
 
         <receiver
             android:name=".receiver.AlarmReceiver"
-            android:exported="false">
+            android:enabled="true"
+            android:exported="true">
             <intent-filter>
-                <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.SCREEN_OFF" />
                 <action android:name="android.intent.action.SCREEN_ON" />
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.DOCK_EVENT" />
+                <action android:name="android.intent.action.USER_PRESENT" />
             </intent-filter>
         </receiver>
+
         <service
             android:name=".services.AlarmBackgroundService"
             android:enabled="true"
             android:stopWithTask="false"
             tools:ignore="Instantiatable">
-            <intent-filter>
-                <action android:name="android.intent.action.SCREEN_OFF" />
-                <action android:name="android.intent.action.SCREEN_ON" />
-            </intent-filter>
+            <!--            <intent-filter>-->
+            <!--                <action android:name="android.intent.action.SCREEN_OFF" />-->
+            <!--                <action android:name="android.intent.action.SCREEN_ON" />-->
+            <!--            </intent-filter>-->
         </service>
+
+        <service android:name=".services.LockScreenService" />
 
     </application>
 

--- a/app/src/main/java/com/jww/alarm/receiver/AlarmReceiver.kt
+++ b/app/src/main/java/com/jww/alarm/receiver/AlarmReceiver.kt
@@ -8,14 +8,22 @@ import android.os.Build
 import android.os.PowerManager
 import android.util.Log
 import com.jww.alarm.services.AlarmBackgroundService
-import com.jww.alarm.views.alarmPlayView.AlarmPlayView
+import com.jww.alarm.services.LockScreenService
+import com.jww.alarm.views.alarmPlayView.AlarmLockScreenView
 
 
 class AlarmReceiver : BroadcastReceiver() {
+
+    companion object {
+        val NOTI_ID_ALARM_RECEVER = 9998
+    }
+
     var sCpuWakeLock: PowerManager.WakeLock? = null
 
     @SuppressLint("InvalidWakeLockTag")
     override fun onReceive(context: Context?, intent: Intent?) {
+
+
         context?.let {
             val pm = it.getSystemService(Context.POWER_SERVICE) as PowerManager
             sCpuWakeLock =
@@ -24,36 +32,64 @@ class AlarmReceiver : BroadcastReceiver() {
                     "test"
                 )
 
-            sCpuWakeLock?.acquire(10 * 1000L /*10 minutes*/)
+            Log.d("Won", "${intent?.action}")
+            sCpuWakeLock?.acquire()
+//            startLockScreenService(it)
+//            startAlarmBackgroundService(it)
+//            startLockScreenActivity(context, intent?.action)
 
-            startAlarmBackgroundService(it)
             sCpuWakeLock?.release()
-            sCpuWakeLock = null
-
+            sCpuWakeLock ?: let {
+                sCpuWakeLock = null
+            }
             Log.d("Won", "2================================")
         }
 
         Log.d("Won", "1================================")
+
+        when (intent?.action) {
+            "com.test" -> {
+                Log.d("Won", "ACTION_BOOT_COMPLETED")
+                startLockScreenActivity(context!!, "com.test")
+            }
+        }
     }
 
     private fun startAlarmBackgroundService(context: Context) {
         Log.d("Won", "startAlarmBackgroundService")
-        val intent = Intent(context, AlarmPlayView::class.java)
-        intent.apply {
-            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        }
-        context.startActivity(intent)
+
         val serviceIntent = Intent(context, AlarmBackgroundService::class.java)
         serviceIntent.apply {
             action = Intent.ACTION_SCREEN_ON
             action = Intent.ACTION_SCREEN_OFF
-
         }
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             context.startForegroundService(serviceIntent);
         } else {
             context.startService(serviceIntent);
         }
+        Log.d("Won", "context = $context")
+    }
 
+    private fun startLockScreenActivity(context: Context, action: String?) {
+        val intent = Intent(context, AlarmLockScreenView::class.java)
+        intent.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        Log.d("Won","startActivity ${action}")
+        context.startActivity(intent)
+    }
+
+    private fun startLockScreenService(context: Context) {
+        val serviceIntent = Intent(context, LockScreenService::class.java)
+        serviceIntent.apply {
+            action = Intent.ACTION_SCREEN_ON
+            action = Intent.ACTION_SCREEN_OFF
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(serviceIntent);
+        } else {
+            context.startService(serviceIntent);
+        }
     }
 }

--- a/app/src/main/java/com/jww/alarm/services/AlarmBackgroundService.kt
+++ b/app/src/main/java/com/jww/alarm/services/AlarmBackgroundService.kt
@@ -14,6 +14,7 @@ import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.jww.alarm.R
 import com.jww.alarm.receiver.AlarmReceiver
+import com.jww.alarm.views.alarmPlayView.AlarmLockScreenView
 
 //https://medium.com/mj-studio/%EC%95%88%EB%93%9C%EB%A1%9C%EC%9D%B4%EB%93%9C-%EC%96%B4%EB%94%94%EA%B9%8C%EC%A7%80-%EC%95%84%EC%84%B8%EC%9A%94-2-1-service-foreground-service-e19cf74df390
 class AlarmBackgroundService : Service() {
@@ -47,7 +48,8 @@ class AlarmBackgroundService : Service() {
         stopSelf()
 
         notificationManager.notify(NOTIFICATION_ID, builder.build())
-        startVibrator(this)
+//        startVibrator(this)
+        startLockScreenActivity()
         return START_STICKY
     }
 
@@ -58,11 +60,17 @@ class AlarmBackgroundService : Service() {
         when (intent.action) {
             Intent.ACTION_SCREEN_OFF -> {
                 Log.d("Won", "ScreenOff")
+//                val intent = Intent(context, AlarmLockScreenView::class.java)
+//                intent.apply {
+//                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+//                }
+//                context.startActivity(intent)
             }
             Intent.ACTION_SCREEN_ON -> {
                 Log.d("Won", "ScreenOn")
             }
         }
+
         val pendingIntent =
             PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
 
@@ -116,8 +124,6 @@ class AlarmBackgroundService : Service() {
     }
 
     private fun startVibrator(context: Context) {
-
-
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val audioAttributes = AudioAttributes.Builder().build()
             vib.vibrate(
@@ -126,5 +132,14 @@ class AlarmBackgroundService : Service() {
         } else {
             vib.vibrate(200000)
         }
+    }
+
+    private fun startLockScreenActivity() {
+        val intent = Intent(this, AlarmLockScreenView::class.java)
+        intent.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        this.startActivity(intent)
+
     }
 }

--- a/app/src/main/java/com/jww/alarm/services/LockScreenService.kt
+++ b/app/src/main/java/com/jww/alarm/services/LockScreenService.kt
@@ -1,0 +1,102 @@
+package com.jww.alarm.services
+
+import android.app.*
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.jww.alarm.R
+import com.jww.alarm.views.alarmPlayView.AlarmLockScreenView
+
+class LockScreenService : Service() {
+
+    companion object {
+        val NOTIFICATION_ID = 8888
+        val CHANNEL_ID = "LockScreenService"
+    }
+
+    lateinit var builder: NotificationCompat.Builder
+    lateinit var notificationManager: NotificationManager
+
+    override fun onCreate() {
+        super.onCreate()
+        notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        intent?.let {
+            createNotification(it, this)
+        }
+        startLockScreenActivity()
+        startForeground(NOTIFICATION_ID, builder.build())
+        stopForeground(true)
+        stopSelf()
+
+//        notificationManager.notify(NOTIFICATION_ID, builder.build())
+
+        return START_STICKY
+    }
+
+    override fun onBind(p0: Intent?): IBinder? {
+        return null
+    }
+
+    private fun createNotification(intent: Intent, context: Context) {
+
+        when (intent.action) {
+            Intent.ACTION_SCREEN_OFF -> {
+                Log.d("Won", "ScreenOff")
+            }
+            Intent.ACTION_SCREEN_ON -> {
+                Log.d("Won", "ScreenOn")
+            }
+        }
+
+        val pullIntent = Intent(this, AlarmLockScreenView::class.java)
+
+        val pendingIntent =
+            PendingIntent.getActivity(context, 0, pullIntent, PendingIntent.FLAG_UPDATE_CURRENT)
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val notificationChannel =
+                NotificationChannel(
+                    CHANNEL_ID,
+                    "jwwAlarmLcok",
+                    NotificationManager.IMPORTANCE_HIGH
+                )
+
+
+            notificationManager.createNotificationChannel(notificationChannel)
+
+            builder = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("락스크린 테스트")
+                .setContentText("락스크린 시간")
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
+
+        } else {
+
+            builder = NotificationCompat.Builder(context)
+                .setSmallIcon(R.drawable.ic_launcher_foreground)
+                .setContentTitle("락스크린 테스트")
+                .setContentText("락스크린 시간")
+                .setVibrate(longArrayOf(0L))
+                .setContentIntent(pendingIntent)
+                .setAutoCancel(true)
+        }
+        builder.build().flags = Notification.FLAG_INSISTENT
+    }
+
+    private fun startLockScreenActivity() {
+        Log.d("Won","startLockScreenActivity")
+        val intent = Intent(applicationContext, AlarmLockScreenView::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        applicationContext.startActivity(intent)
+
+    }
+}

--- a/app/src/main/java/com/jww/alarm/views/alarmPlayView/AlarmLockScreenView.kt
+++ b/app/src/main/java/com/jww/alarm/views/alarmPlayView/AlarmLockScreenView.kt
@@ -14,7 +14,7 @@ import com.jww.alarm.R
 import com.jww.alarm.bases.BaseActivity
 import com.jww.alarm.databinding.FragmentAlarmPlayBinding
 
-class AlarmPlayView : BaseActivity() {
+class AlarmLockScreenView : BaseActivity() {
     private var _binding: FragmentAlarmPlayBinding? = null
     private val binding
         get() = _binding!!
@@ -24,6 +24,7 @@ class AlarmPlayView : BaseActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d("Won","AlarmPlayView create()")
         initLockScreen()
         _binding = FragmentAlarmPlayBinding.inflate(layoutInflater)
         setContentView(binding.root)
@@ -31,6 +32,7 @@ class AlarmPlayView : BaseActivity() {
         startVibrator()
         startSound()
         binds()
+        Log.d("Won","AlarmPlayView create() end")
     }
 
     private fun binds() {

--- a/app/src/main/java/com/jww/alarm/views/registerAlarmView/RegisterAlarmFragment.kt
+++ b/app/src/main/java/com/jww/alarm/views/registerAlarmView/RegisterAlarmFragment.kt
@@ -16,7 +16,6 @@ import com.jww.alarm.MainActivity
 import com.jww.alarm.bases.BaseFragment
 import com.jww.alarm.databinding.FragmentRegisterAlarmBinding
 import com.jww.alarm.receiver.AlarmReceiver
-import com.jww.alarm.services.AlarmBackgroundService.Companion.NOTIFICATION_ID
 
 class RegisterAlarmFragment : BaseFragment() {
 
@@ -117,15 +116,20 @@ class RegisterAlarmFragment : BaseFragment() {
         val alarmManager =
             currentAct.getSystemService(AppCompatActivity.ALARM_SERVICE) as AlarmManager
         val intent = Intent(currentAct, AlarmReceiver::class.java)
+//        intent.action = "com.test"
+//        intent.action = Intent.ACTION_SCREEN_ON
+//        intent.action = Intent.ACTION_BOOT_COMPLETED
+//        intent.action = Intent.ACTION_SCREEN_OFF
+
 
         val pendingIntent = PendingIntent.getBroadcast(
             currentAct,
-            NOTIFICATION_ID,
+            AlarmReceiver.NOTI_ID_ALARM_RECEVER,
             intent,
             PendingIntent.FLAG_UPDATE_CURRENT
         )
 
-        Log.d("Won","Alarm Intent")
+        Log.d("Won", "Alarm Intent")
         alarmManager.setExactAndAllowWhileIdle(
             AlarmManager.ELAPSED_REALTIME_WAKEUP,
             SystemClock.elapsedRealtime() + (10 * 1000),


### PR DESCRIPTION
1. broadcastReceive에서 액티비티 실행(실행 안됨)
2. backgroundService에서 액티비티 실행( 실행 안됨)

- 안드로이드 q에서 부터는 백그라운드 에서 액티비티 실행을 못하도록 제한
- 액티비티를 실행하려면 앱이 foreground에 있을떄 가능

= 시스템 브로드 캐스트를 받았을떄
- 앱 인텐트를 브로드 캐스트로 받았을때 UI를 실행할 것이라고 예상되는 인텐트들이 있습니다.
이런 인텐트들 브로드 캐스트로 받으면 몇초간은 백그라운드에서 액티비티를 실행 할수 있다고 함

= Notificaiton으로 액티비티 실행
- 알람이나 전화가 왔을때 처럼 갑자기 다른 화면으로 전환해야 하는 경우가 있습니다.
백그라운드 서비스는 액티비티를 실행하지 못하기 때문에 노티피케이션을 만들어 사용자가 앱을 실행할 필요가 있다고 알려짐
(Notification의 full screen intent 사용 하지만 100% 액티비티가 실행되지 않다고함(버전별 이슈))

테스트
1. broadcastReceive에서 action을 추가하여 action을 받을때 액티비티 실행
- 커스텀 action을 추가하여 broadcastReceive를 호출하면 되지만 시스템 액션을 추가하여 호출하면 안됨,
manifest에서만 추가할것
- broadcastReceive에서 action 값은 못얻어옴, 커스텀 액션만 받아옴, broadcastRecevie 클래스 까지는 호출됨